### PR TITLE
patches/0001: update hevce for upstream interface change

### DIFF
--- a/patches/0001-va-Implement-the-vah265enc-plugin-for-va-HEVC-encodi.patch
+++ b/patches/0001-va-Implement-the-vah265enc-plugin-for-va-HEVC-encodi.patch
@@ -1,22 +1,22 @@
-From 55266c03d77c0273648f6c1ab04e6b0d8942f569 Mon Sep 17 00:00:00 2001
+From 2f4f48a12b7bf35d8ac7234b3e00d97bc2d32106 Mon Sep 17 00:00:00 2001
 From: He Junyan <junyan.he@intel.com>
 Date: Fri, 25 Mar 2022 21:54:30 +0800
-Subject: [PATCH 1/8] va: Implement the vah265enc plugin for va HEVC encoding.
+Subject: [PATCH] va: Implement the vah265enc plugin for va HEVC encoding.
 
 ---
- .../gst-plugins-bad/sys/va/gstvah265enc.c     | 4461 +++++++++++++++++
+ .../gst-plugins-bad/sys/va/gstvah265enc.c     | 4459 +++++++++++++++++
  .../gst-plugins-bad/sys/va/gstvah265enc.h     |   34 +
  .../gst-plugins-bad/sys/va/meson.build        |    1 +
- 3 files changed, 4496 insertions(+)
+ 3 files changed, 4494 insertions(+)
  create mode 100644 subprojects/gst-plugins-bad/sys/va/gstvah265enc.c
  create mode 100644 subprojects/gst-plugins-bad/sys/va/gstvah265enc.h
 
 diff --git a/subprojects/gst-plugins-bad/sys/va/gstvah265enc.c b/subprojects/gst-plugins-bad/sys/va/gstvah265enc.c
 new file mode 100644
-index 0000000000..fde75a9dde
+index 000000000000..3bb707986af2
 --- /dev/null
 +++ b/subprojects/gst-plugins-bad/sys/va/gstvah265enc.c
-@@ -0,0 +1,4461 @@
+@@ -0,0 +1,4459 @@
 +/* GStreamer
 + *  Copyright (C) 2022 Intel Corporation
 + *     Author: He Junyan <junyan.he@intel.com>
@@ -3300,10 +3300,8 @@ index 0000000000..fde75a9dde
 +
 +  self->packed_headers = 0;
 +
-+  packed_headers = gst_va_encoder_get_packed_headers (base->encoder,
-+      base->profile, base->entrypoint);
-+
-+  if (packed_headers == 0)
++  if (!gst_va_encoder_get_packed_headers (base->encoder, base->profile,
++          base->entrypoint, &packed_headers))
 +    return FALSE;
 +
 +  if (desired_packed_headers & ~packed_headers) {
@@ -4480,7 +4478,7 @@ index 0000000000..fde75a9dde
 +}
 diff --git a/subprojects/gst-plugins-bad/sys/va/gstvah265enc.h b/subprojects/gst-plugins-bad/sys/va/gstvah265enc.h
 new file mode 100644
-index 0000000000..08501c2395
+index 000000000000..08501c2395b1
 --- /dev/null
 +++ b/subprojects/gst-plugins-bad/sys/va/gstvah265enc.h
 @@ -0,0 +1,34 @@
@@ -4519,7 +4517,7 @@ index 0000000000..08501c2395
 +
 +G_END_DECLS
 diff --git a/subprojects/gst-plugins-bad/sys/va/meson.build b/subprojects/gst-plugins-bad/sys/va/meson.build
-index fee1fedde6..e04366e127 100644
+index fee1fedde64e..e04366e127dd 100644
 --- a/subprojects/gst-plugins-bad/sys/va/meson.build
 +++ b/subprojects/gst-plugins-bad/sys/va/meson.build
 @@ -15,6 +15,7 @@ va_sources = [
@@ -4531,5 +4529,5 @@ index fee1fedde6..e04366e127 100644
    'gstvampeg2dec.c',
    'gstvaprofile.c',
 -- 
-2.25.1
+2.34.3
 


### PR DESCRIPTION
Fixes compile error due to gst_va_encoder_get_packed_headers
interface change in upstream at:

https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2851