### PR TITLE
msdk: Add more formats support in windows mapping_data func

### DIFF
--- a/patches/0012-msdk-Use-va-libs-API-to-get-VA-surface-from-buffer.patch
+++ b/patches/0012-msdk-Use-va-libs-API-to-get-VA-surface-from-buffer.patch
@@ -1,4 +1,4 @@
-From 9a90090ce4a7759b8833dcd11f475504f01e5e81 Mon Sep 17 00:00:00 2001
+From 3d1945652e66c367b076bb0ccd30e6916b1eaa4f Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Thu, 3 Mar 2022 10:07:19 +0800
 Subject: [PATCH 12/21] msdk: Use va libs API to get VA surface from buffer

--- a/patches/0013-msdkenc-Directly-import-va-memory-as-mfx-surface.patch
+++ b/patches/0013-msdkenc-Directly-import-va-memory-as-mfx-surface.patch
@@ -1,4 +1,4 @@
-From 0edea54d26de350212366abe5a449ef87cdb6baa Mon Sep 17 00:00:00 2001
+From ed379efad8389b09580e03ca691be1182d424955 Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Thu, 21 Apr 2022 17:27:09 +0800
 Subject: [PATCH 13/21] msdkenc: Directly import va memory as mfx surface

--- a/patches/0014-msdkenc-Directly-import-dmabuf-memory-as-mfx-surface.patch
+++ b/patches/0014-msdkenc-Directly-import-dmabuf-memory-as-mfx-surface.patch
@@ -1,4 +1,4 @@
-From 3c672acff874ca9c72eb1f76dc03f32955981083 Mon Sep 17 00:00:00 2001
+From ff57f3bd3f8ba10333282a1be3d6083e1e39279f Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Thu, 19 May 2022 18:57:50 +0800
 Subject: [PATCH 14/21] msdkenc: Directly import dmabuf memory as mfx surface

--- a/patches/0015-msdkenc-Use-va-pool-on-linux-and-system-pool-for-win.patch
+++ b/patches/0015-msdkenc-Use-va-pool-on-linux-and-system-pool-for-win.patch
@@ -1,4 +1,4 @@
-From ae4074d7990b046ea8e37256a7f2d9905c2f7e8e Mon Sep 17 00:00:00 2001
+From 5983643f3f39821b9ba29acc55824de92bd56f32 Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Thu, 19 May 2022 19:18:21 +0800
 Subject: [PATCH 15/21] msdkenc: Use va pool on linux and system pool for

--- a/patches/0016-msdk-Add-help-functions-to-get-mfxFrameSurface1-from.patch
+++ b/patches/0016-msdk-Add-help-functions-to-get-mfxFrameSurface1-from.patch
@@ -1,4 +1,4 @@
-From a2ae5764f75907f2c3e02c11dd1514f0926d663b Mon Sep 17 00:00:00 2001
+From a7384cc2c282be553f1898ff5734a561c5e5453f Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Fri, 27 May 2022 17:56:33 +0800
 Subject: [PATCH 16/21] msdk: Add help functions to get mfxFrameSurface1 from
@@ -6,21 +6,21 @@ Subject: [PATCH 16/21] msdk: Add help functions to get mfxFrameSurface1 from
 
 Note that the memory abstraction for system memory is for windows path.
 ---
- .../sys/msdk/gstmsdkallocator.c               | 103 ++++++++++++++++
+ .../sys/msdk/gstmsdkallocator.c               | 151 ++++++++++++++++++
  .../sys/msdk/gstmsdkallocator.h               |  10 ++
- .../sys/msdk/gstmsdkallocator_libva.c         | 114 ++++++++++++++++++
+ .../sys/msdk/gstmsdkallocator_libva.c         | 114 +++++++++++++
  .../sys/msdk/gstmsdkallocator_libva.h         |   4 +
  .../gst-plugins-bad/sys/msdk/meson.build      |   1 +
  subprojects/gst-plugins-bad/sys/msdk/msdk.h   |   1 +
- 6 files changed, 233 insertions(+)
+ 6 files changed, 281 insertions(+)
  create mode 100644 subprojects/gst-plugins-bad/sys/msdk/gstmsdkallocator.c
 
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkallocator.c b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkallocator.c
 new file mode 100644
-index 0000000000..ddda551b61
+index 0000000000..2ea71325d7
 --- /dev/null
 +++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkallocator.c
-@@ -0,0 +1,103 @@
+@@ -0,0 +1,151 @@
 +/*
 + * GStreamer Intel MSDK plugin
 + * Copyright (c) 2022 Intel Corporation. All rights reserved.
@@ -68,8 +68,33 @@ index 0000000000..ddda551b61
 +  switch (GST_VIDEO_INFO_FORMAT (&info)) {
 +    case GST_VIDEO_FORMAT_NV12:
 +    case GST_VIDEO_FORMAT_P010_10LE:
++    case GST_VIDEO_FORMAT_P012_LE:
 +      mfx_surface->Data.Y = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 0);
 +      mfx_surface->Data.UV = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 1);
++      mfx_surface->Data.Pitch = (mfxU16) stride;
++      break;
++    case GST_VIDEO_FORMAT_YV12:
++      mfx_surface->Data.Y = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 0);
++      mfx_surface->Data.U = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 2);
++      mfx_surface->Data.V = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 1);
++      mfx_surface->Data.Pitch = (mfxU16) stride;
++      break;
++    case GST_VIDEO_FORMAT_I420:
++      mfx_surface->Data.Y = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 0);
++      mfx_surface->Data.U = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 1);
++      mfx_surface->Data.V = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 2);
++      mfx_surface->Data.Pitch = (mfxU16) stride;
++      break;
++    case GST_VIDEO_FORMAT_YUY2:
++      mfx_surface->Data.Y = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 0);
++      mfx_surface->Data.U = mfx_surface->Data.Y + 1;
++      mfx_surface->Data.V = mfx_surface->Data.Y + 3;
++      mfx_surface->Data.Pitch = (mfxU16) stride;
++      break;
++    case GST_VIDEO_FORMAT_UYVY:
++      mfx_surface->Data.Y = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 0);
++      mfx_surface->Data.U = mfx_surface->Data.Y;
++      mfx_surface->Data.V = mfx_surface->Data.U + 2;
 +      mfx_surface->Data.Pitch = (mfxU16) stride;
 +      break;
 +    case GST_VIDEO_FORMAT_VUYA:
@@ -80,12 +105,35 @@ index 0000000000..ddda551b61
 +      mfx_surface->Data.PitchHigh = (mfxU16) (stride / (1 << 16));
 +      mfx_surface->Data.PitchLow = (mfxU16) (stride % (1 << 16));
 +      break;
++    case GST_VIDEO_FORMAT_BGRA:
++    case GST_VIDEO_FORMAT_BGRx:
++      mfx_surface->Data.B = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 0);
++      mfx_surface->Data.G = mfx_surface->Data.B + 1;
++      mfx_surface->Data.R = mfx_surface->Data.B + 2;
++      mfx_surface->Data.A = mfx_surface->Data.B + 3;
++      mfx_surface->Data.Pitch = (mfxU16) stride;
++      break;
++    case GST_VIDEO_FORMAT_Y210:
++    case GST_VIDEO_FORMAT_Y212_LE:
++      mfx_surface->Data.Y = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 0);
++      mfx_surface->Data.U = mfx_surface->Data.Y + 2;
++      mfx_surface->Data.V = mfx_surface->Data.Y + 6;
++      mfx_surface->Data.Pitch = (mfxU16) stride;
++      break;
 +    case GST_VIDEO_FORMAT_Y410:
 +      mfx_surface->Data.Y410 =
 +          (mfxY410 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 0);
 +      mfx_surface->Data.Pitch = stride;
 +      break;
++    case GST_VIDEO_FORMAT_Y412_LE:
++      mfx_surface->Data.U = (mfxU8 *) GST_VIDEO_FRAME_PLANE_DATA (&frame, 0);
++      mfx_surface->Data.Y = mfx_surface->Data.Y + 2;
++      mfx_surface->Data.V = mfx_surface->Data.Y + 4;
++      mfx_surface->Data.A = mfx_surface->Data.Y + 6;
++      mfx_surface->Data.Pitch = (mfxU16) stride;
++      break;
 +    default:
++      g_assert_not_reached ();
 +      break;
 +  }
 +

--- a/patches/0017-msdkenc-Apply-common-util-func-to-import-mem-as-msdk.patch
+++ b/patches/0017-msdkenc-Apply-common-util-func-to-import-mem-as-msdk.patch
@@ -1,4 +1,4 @@
-From f72b71319b7398b8e8347ae34e9c9274e1509fa7 Mon Sep 17 00:00:00 2001
+From c482a37887017fdbf48ae889a705878c1f6b78f0 Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Thu, 25 Aug 2022 17:28:36 +0800
 Subject: [PATCH 17/21] msdkenc: Apply common util func to import mem as

--- a/patches/0018-msdkvpp-Add-va-caps-at-sink-and-src-pad.patch
+++ b/patches/0018-msdkvpp-Add-va-caps-at-sink-and-src-pad.patch
@@ -1,4 +1,4 @@
-From 1a2e5889756cff27ee59fa56122bf95d296fccfd Mon Sep 17 00:00:00 2001
+From 5cbf970ba99c2dcb0eb5a00c7337dbdfc8767acb Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Mon, 9 May 2022 18:19:01 +0800
 Subject: [PATCH 18/21] msdkvpp: Add va caps at sink and src pad

--- a/patches/0019-msdkvpp-Import-buffer-to-msdk_surface.patch
+++ b/patches/0019-msdkvpp-Import-buffer-to-msdk_surface.patch
@@ -1,4 +1,4 @@
-From 31641ca4c883bae5dc5efbbe740da18017c80fcb Mon Sep 17 00:00:00 2001
+From 3914962d855dba5c60e5b0d84089b1045477addd Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Mon, 9 May 2022 18:34:38 +0800
 Subject: [PATCH 19/21] msdkvpp: Import buffer to msdk_surface

--- a/patches/0020-msdkvpp-Use-va-pool-at-linux-path-and-system-pool-fo.patch
+++ b/patches/0020-msdkvpp-Use-va-pool-at-linux-path-and-system-pool-fo.patch
@@ -1,4 +1,4 @@
-From 236612e66c74d5821b4ec8f5f352b6e0811a6e1c Mon Sep 17 00:00:00 2001
+From e0be2c8886908600291288b8b34722a9c0b484d2 Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Wed, 8 Jun 2022 12:31:56 +0800
 Subject: [PATCH 20/21] msdkvpp : Use va pool at linux path and system pool for

--- a/patches/0021-msdkvpp-Add-va-memory-when-fixating-src-caps.patch
+++ b/patches/0021-msdkvpp-Add-va-memory-when-fixating-src-caps.patch
@@ -1,4 +1,4 @@
-From f56741a2b16f7f05756176f1f0b9b3b19db721c5 Mon Sep 17 00:00:00 2001
+From 9369276dd01fdb3fe8a1a23e9183f0b099cd6f48 Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Thu, 26 May 2022 18:17:16 +0800
 Subject: [PATCH 21/21] msdkvpp: Add va memory when fixating src caps


### PR DESCRIPTION
For gst-msdk windows path, which currently only supports system memory, we need the map_data function to fill the YUV plane in mfxFrameSurface1. Add more formats in the map_data function.