### PR TITLE
msdkdec: Update dec refact

### DIFF
--- a/patches/0020-msdkdec-Enable-va-caps-at-srcpad.patch
+++ b/patches/0020-msdkdec-Enable-va-caps-at-srcpad.patch
@@ -1,4 +1,4 @@
-From 79d51dd275168316a164d8740bb9b0270053b113 Mon Sep 17 00:00:00 2001
+From 45ec197e74a2a28d97e49f3570fb72fc0ccbe278 Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Wed, 8 Jun 2022 17:13:47 +0800
 Subject: [PATCH 20/26] msdkdec: Enable va caps at srcpad
@@ -6,14 +6,14 @@ Subject: [PATCH 20/26] msdkdec: Enable va caps at srcpad
 Set caps with VA memory at src pad with a higher priority, then comes
 dmabuf caps.
 ---
- .../gst-plugins-bad/sys/msdk/gstmsdkav1dec.c  | 11 +++++--
- .../gst-plugins-bad/sys/msdk/gstmsdkdec.c     | 31 +++++++++++++------
- .../gst-plugins-bad/sys/msdk/gstmsdkh264dec.c | 11 +++++--
- .../gst-plugins-bad/sys/msdk/gstmsdkh265dec.c | 11 +++++--
- .../sys/msdk/gstmsdkmjpegdec.c                | 11 +++++--
- .../sys/msdk/gstmsdkmpeg2dec.c                | 14 +++++++++
+ .../gst-plugins-bad/sys/msdk/gstmsdkav1dec.c  | 11 ++++--
+ .../gst-plugins-bad/sys/msdk/gstmsdkdec.c     | 34 +++++++++++++------
+ .../gst-plugins-bad/sys/msdk/gstmsdkh264dec.c | 11 ++++--
+ .../gst-plugins-bad/sys/msdk/gstmsdkh265dec.c | 11 ++++--
+ .../sys/msdk/gstmsdkmjpegdec.c                | 11 ++++--
+ .../sys/msdk/gstmsdkmpeg2dec.c                | 14 ++++++++
  .../gst-plugins-bad/sys/msdk/gstmsdkvp9dec.c  | 12 +++++--
- 7 files changed, 82 insertions(+), 19 deletions(-)
+ 7 files changed, 83 insertions(+), 21 deletions(-)
 
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkav1dec.c b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkav1dec.c
 index 5e3ab9e08b..46cb9f18f2 100644
@@ -45,7 +45,7 @@ index 5e3ab9e08b..46cb9f18f2 100644
  #define gst_msdkav1dec_parent_class parent_class
  G_DEFINE_TYPE (GstMsdkAV1Dec, gst_msdkav1dec, GST_TYPE_MSDKDEC);
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
-index ba9c444c21..ce2c0d5f8e 100644
+index bc7fb52884..dbeb9490cd 100644
 --- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
 +++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
 @@ -41,6 +41,10 @@
@@ -59,7 +59,7 @@ index ba9c444c21..ce2c0d5f8e 100644
  GST_DEBUG_CATEGORY_EXTERN (gst_msdkdec_debug);
  #define GST_CAT_DEFAULT gst_msdkdec_debug
  
-@@ -564,16 +568,20 @@ _gst_caps_has_feature (const GstCaps * caps, const gchar * feature)
+@@ -567,26 +571,28 @@ _gst_caps_has_feature (const GstCaps * caps, const gchar * feature)
  }
  
  static gboolean
@@ -85,8 +85,9 @@ index ba9c444c21..ce2c0d5f8e 100644
    if (!out_caps)
      goto done;
  
-@@ -581,9 +589,8 @@ srcpad_can_dmabuf (GstMsdkDec * thiz)
-       || out_caps == caps)
+-  if (gst_caps_is_any (out_caps) || gst_caps_is_empty (out_caps)
+-      || out_caps == caps)
++  if (gst_caps_is_any (out_caps) || gst_caps_is_empty (out_caps))
      goto done;
  
 -  if (_gst_caps_has_feature (out_caps, GST_CAPS_FEATURE_MEMORY_DMABUF))
@@ -96,7 +97,7 @@ index ba9c444c21..ce2c0d5f8e 100644
  done:
    if (caps)
      gst_caps_unref (caps);
-@@ -745,10 +752,16 @@ gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
+@@ -748,10 +754,16 @@ gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
      gst_msdk_set_video_alignment (vinfo, alloc_w, alloc_h, &align);
    gst_video_info_align (vinfo, &align);
    output_state->caps = gst_video_info_to_caps (vinfo);
@@ -180,7 +181,7 @@ index 6d515167ff..c3c9fe0e3c 100644
 @@ -67,11 +67,18 @@ static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
          "width = (int) [ 1, MAX ], height = (int) [ 1, MAX ], parsed = true ")
      );
-
+ 
 +#ifndef _WIN32
 +#define VA_SRC_CAPS_STR \
 +    "; "  GST_MSDK_CAPS_MAKE_WITH_VA_FEATURE ("{ NV12 }")
@@ -195,7 +196,7 @@ index 6d515167ff..c3c9fe0e3c 100644
 -    );
 +    GST_STATIC_CAPS (GST_MSDK_CAPS_STR ("{ NV12, YUY2 }", "{ NV12, YUY2 }")
 +        VA_SRC_CAPS_STR));
-
+ 
  #define gst_msdkmjpegdec_parent_class parent_class
  G_DEFINE_TYPE (GstMsdkMJPEGDec, gst_msdkmjpegdec, GST_TYPE_MSDKDEC);
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkmpeg2dec.c b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkmpeg2dec.c
@@ -205,7 +206,7 @@ index 4d2f9267f8..688a1957b3 100644
 @@ -57,6 +57,13 @@
  GST_DEBUG_CATEGORY_EXTERN (gst_msdkmpeg2dec_debug);
  #define GST_CAT_DEFAULT gst_msdkmpeg2dec_debug
-
+ 
 +#ifndef _WIN32
 +#define VA_SRC_CAPS_STR \
 +    "; " GST_MSDK_CAPS_MAKE_WITH_VA_FEATURE ("{ NV12 }")
@@ -219,7 +220,7 @@ index 4d2f9267f8..688a1957b3 100644
 @@ -65,6 +72,12 @@ static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
          "mpegversion = (int) 2, " "systemstream = (boolean) false")
      );
-
+ 
 +static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
 +    GST_PAD_SRC,
 +    GST_PAD_ALWAYS,
@@ -228,14 +229,14 @@ index 4d2f9267f8..688a1957b3 100644
 +
  #define gst_msdkmpeg2dec_parent_class parent_class
  G_DEFINE_TYPE (GstMsdkMPEG2Dec, gst_msdkmpeg2dec, GST_TYPE_MSDKDEC);
-
+ 
 @@ -151,6 +164,7 @@ gst_msdkmpeg2dec_class_init (GstMsdkMPEG2DecClass * klass)
    gst_msdkdec_prop_install_output_oder_property (gobject_class);
-
+ 
    gst_element_class_add_static_pad_template (element_class, &sink_factory);
 +  gst_element_class_add_static_pad_template (element_class, &src_factory);
  }
-
+ 
  static void
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvp9dec.c b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvp9dec.c
 index 847d6529e7..3056a7dd5b 100644
@@ -243,7 +244,7 @@ index 847d6529e7..3056a7dd5b 100644
 +++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvp9dec.c
 @@ -58,6 +58,14 @@ GST_DEBUG_CATEGORY_EXTERN (gst_msdkvp9dec_debug);
  #define GST_CAT_DEFAULT gst_msdkvp9dec_debug
-
+ 
  #define COMMON_FORMAT "{ NV12, P010_10LE, VUYA, Y410, P012_LE, Y412_LE }"
 +#define SUPPORTED_VA_FORMAT "{ NV12 }"
 +
@@ -253,7 +254,7 @@ index 847d6529e7..3056a7dd5b 100644
 +#else
 +#define VA_SRC_CAPS_STR ""
 +#endif
-
+ 
  static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
      GST_PAD_SINK,
 @@ -68,8 +76,8 @@ static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
@@ -264,7 +265,7 @@ index 847d6529e7..3056a7dd5b 100644
 -    );
 +    GST_STATIC_CAPS (GST_MSDK_CAPS_STR (COMMON_FORMAT, COMMON_FORMAT)
 +        VA_SRC_CAPS_STR));
-
+ 
  #define gst_msdkvp9dec_parent_class parent_class
  G_DEFINE_TYPE (GstMsdkVP9Dec, gst_msdkvp9dec, GST_TYPE_MSDKDEC);
 -- 

--- a/patches/0021-msdk-Add-a-bufferpool-in-GstMsdkContext-structure.patch
+++ b/patches/0021-msdk-Add-a-bufferpool-in-GstMsdkContext-structure.patch
@@ -1,4 +1,4 @@
-From 5f9883b596d8a1dedced5ebdb5bbc07eabb0c203 Mon Sep 17 00:00:00 2001
+From fae49ea80c943db9f4d1879a8fbca5d72035b03d Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Mon, 22 Aug 2022 17:44:35 +0800
 Subject: [PATCH 21/26] msdk: Add a bufferpool in GstMsdkContext structure

--- a/patches/0022-msdkdec-Add-a-function-to-directly-allocate-output-G.patch
+++ b/patches/0022-msdkdec-Add-a-function-to-directly-allocate-output-G.patch
@@ -1,4 +1,4 @@
-From 3dd6aca5c9c57cd4c60501feeda65949d79bfdd2 Mon Sep 17 00:00:00 2001
+From 458278723941dbe75e7ca57c8ac6b3a0cda6428e Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Mon, 22 Aug 2022 18:33:35 +0800
 Subject: [PATCH 22/26] msdkdec: Add a function to directly allocate output
@@ -69,7 +69,7 @@ index b1a2d29a9e..e9f0125bae 100644
  mfxStatus
  gst_msdk_frame_alloc (mfxHDL pthis, mfxFrameAllocRequest * req,
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
-index ce2c0d5f8e..4a8157804d 100644
+index dbeb9490cd..ad83aa3ae3 100644
 --- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
 +++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
 @@ -42,6 +42,7 @@
@@ -80,7 +80,7 @@ index ce2c0d5f8e..4a8157804d 100644
  #include <gst/va/gstvaallocator.h>
  #endif
  
-@@ -64,6 +65,8 @@ static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
+@@ -67,6 +68,8 @@ static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
  
  #define MFX_TIME_IS_VALID(time) ((time) != MFX_TIMESTAMP_UNKNOWN)
  
@@ -89,7 +89,7 @@ index ce2c0d5f8e..4a8157804d 100644
  #define gst_msdkdec_parent_class parent_class
  G_DEFINE_TYPE (GstMsdkDec, gst_msdkdec, GST_TYPE_VIDEO_DECODER);
  
-@@ -286,6 +289,76 @@ failed_unref_buffer:
+@@ -289,6 +292,76 @@ failed_unref_buffer:
    return NULL;
  }
  

--- a/patches/0023-msdkallocator-Use-negotiated-pool-to-alloc-surfaces-.patch
+++ b/patches/0023-msdkallocator-Use-negotiated-pool-to-alloc-surfaces-.patch
@@ -1,4 +1,4 @@
-From 0f2429ea4f15169f078e516ca605679222db7a15 Mon Sep 17 00:00:00 2001
+From 4eb12a954876b80e28a89953a7c1202caeb44241 Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Tue, 23 Aug 2022 10:48:50 +0800
 Subject: [PATCH 23/26] msdkallocator: Use negotiated pool to alloc surfaces in
@@ -105,7 +105,7 @@ index e9f0125bae..83bdd26014 100644
 -      format = VA_RT_FORMAT_RGB32_10;
 -#endif
 +  msdk_resp = g_slice_new0 (GstMsdkAllocResponse);
-
+ 
 -#if ((MFX_VERSION >= 1027) && VA_CHECK_VERSION(1, 2, 0))
 -    if (format == VA_RT_FORMAT_YUV422 && va_fourcc == VA_FOURCC_Y210)
 -      format = VA_RT_FORMAT_YUV422_10;
@@ -119,7 +119,7 @@ index e9f0125bae..83bdd26014 100644
 +    GstVideoInfo info;
 +    GstCaps *caps;
 +    GstVideoAlignment align;
-
+ 
 -#if ((MFX_VERSION >= 1031) && VA_CHECK_VERSION(1, 2, 0))
 -    if (format == VA_RT_FORMAT_YUV420 && va_fourcc == VA_FOURCC_P016)
 -      format = VA_RT_FORMAT_YUV420_12;
@@ -132,12 +132,12 @@ index e9f0125bae..83bdd26014 100644
 +    gst_msdk_set_video_alignment
 +        (&info, req->Info.Width, req->Info.Height, &align);
 +    gst_video_info_align (&info, &align);
-
+ 
 -    if (format == VA_RT_FORMAT_YUV444 && va_fourcc == VA_FOURCC_Y416)
 -      format = VA_RT_FORMAT_YUV444_12;
 -#endif
 +    caps = gst_video_info_to_caps (&info);
-
+ 
 -#if (MFX_VERSION >= 2004)
 -    if (format == VA_RT_FORMAT_YUV444 && (va_fourcc == VA_FOURCC_RGBP
 -            || va_fourcc == VA_FOURCC_BGRP))
@@ -177,7 +177,7 @@ index e9f0125bae..83bdd26014 100644
 +    gst_buffer_pool_config_add_option (config,
 +        GST_BUFFER_POOL_OPTION_VIDEO_ALIGNMENT);
 +    gst_buffer_pool_config_set_va_alignment (config, &align);
-
+ 
 -        status = gst_msdk_get_mfx_status_from_va_status (va_status);
 +    gst_buffer_pool_set_config (pool, config);
 +    gst_buffer_pool_set_active (pool, TRUE);
@@ -196,7 +196,7 @@ index e9f0125bae..83bdd26014 100644
 -        }
 +    for (i = 0; i < surfaces_num; i++) {
 +      GstBuffer *buf;
-
+ 
 -        msdk_mids[i].desc = va_desc;
 +      if (gst_buffer_pool_acquire_buffer (pool, &buf, NULL) != GST_FLOW_OK) {
 +        GST_ERROR ("Failed to allocate buffer");
@@ -204,7 +204,7 @@ index e9f0125bae..83bdd26014 100644
 +        gst_object_unref (pool);
 +        goto error_alloc;
        }
-
+ 
 -      /* Don't use image for DMABuf */
 -      msdk_mids[i].image.image_id = VA_INVALID_ID;
 -      msdk_mids[i].image.buf = VA_INVALID_ID;
@@ -228,11 +228,11 @@ index e9f0125bae..83bdd26014 100644
       */
      VAContextID context_id = req->AllocId;
 @@ -223,6 +158,7 @@ gst_msdk_frame_alloc (mfxHDL pthis, mfxFrameAllocRequest * req,
-
+ 
      for (i = 0; i < surfaces_num; i++) {
        VABufferID coded_buf;
 +      GstMsdkMemoryID msdk_mid;
-
+ 
        va_status = vaCreateBuffer (gst_msdk_context_get_handle (context),
            context_id, VAEncCodedBufferType, codedbuf_size, 1, NULL, &coded_buf);
 @@ -233,15 +169,14 @@ gst_msdk_frame_alloc (mfxHDL pthis, mfxFrameAllocRequest * req,
@@ -244,13 +244,13 @@ index e9f0125bae..83bdd26014 100644
 -      msdk_mids[i].fourcc = fourcc;
 +      msdk_mid.surface = coded_buf;
 +      msdk_mid.fourcc = fourcc;
-
+ 
        /* Don't use image for P208 */
 -      msdk_mids[i].image.image_id = VA_INVALID_ID;
 -      msdk_mids[i].image.buf = VA_INVALID_ID;
 +      msdk_mid.image.image_id = VA_INVALID_ID;
 +      msdk_mid.image.buf = VA_INVALID_ID;
-
+ 
 -      mids[i] = (mfxMemId *) & msdk_mids[i];
 +      mids[i] = (mfxMemId *) & msdk_mid;
      }

--- a/patches/0024-msdkdec-Add-a-function-to-create-va-pool.patch
+++ b/patches/0024-msdkdec-Add-a-function-to-create-va-pool.patch
@@ -1,4 +1,4 @@
-From 6886d28be5beeff7e8d2fed4563a29711aa67e1b Mon Sep 17 00:00:00 2001
+From 41a33c46286b9ea56e2929e009982398b4868f6a Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Tue, 23 Aug 2022 11:25:15 +0800
 Subject: [PATCH 24/26] msdkdec: Add a function to create va pool
@@ -13,10 +13,10 @@ when all the memory allocation modifications are ready in the commits after.
  2 files changed, 107 insertions(+), 6 deletions(-)
 
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
-index 4a8157804d..c222e2cbdf 100644
+index ad83aa3ae3..b82d21e31b 100644
 --- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
 +++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
-@@ -580,6 +580,7 @@ gst_msdkdec_init_decoder (GstMsdkDec * thiz)
+@@ -583,6 +583,7 @@ gst_msdkdec_init_decoder (GstMsdkDec * thiz)
  #endif
  
      gst_msdk_frame_alloc (thiz->context, &request, &thiz->alloc_resp);
@@ -24,7 +24,7 @@ index 4a8157804d..c222e2cbdf 100644
    }
  
    /* update the prealloc_buffer count, which will be used later
-@@ -1008,12 +1009,7 @@ gst_msdkdec_finish_task (GstMsdkDec * thiz, MsdkDecTask * task)
+@@ -1010,12 +1011,7 @@ gst_msdkdec_finish_task (GstMsdkDec * thiz, MsdkDecTask * task)
          GST_MINI_OBJECT_FLAG_SET (surface->buf, GST_MINI_OBJECT_FLAG_LOCKABLE);
          frame->output_buffer = gst_buffer_ref (surface->buf);
        } else {
@@ -38,7 +38,7 @@ index 4a8157804d..c222e2cbdf 100644
          frame->output_buffer = gst_buffer_ref (surface->copy.buffer);
          unmap_frame (thiz, surface);
        }
-@@ -1797,6 +1793,105 @@ error_pool_config:
+@@ -1801,6 +1797,105 @@ error_pool_config:
    }
  }
  
@@ -75,7 +75,7 @@ index 4a8157804d..c222e2cbdf 100644
 +  pool =
 +      gst_va_pool_new_with_config (caps,
 +      GST_VIDEO_INFO_SIZE (info), num_buffers, num_buffers,
-+      VA_SURFACE_ATTRIB_USAGE_HINT_GENERIC, GST_VA_FEATURE_AUTO,
++      VA_SURFACE_ATTRIB_USAGE_HINT_DECODER, GST_VA_FEATURE_AUTO,
 +      allocator, &alloc_params);
 +
 +  gst_object_unref (allocator);
@@ -144,7 +144,7 @@ index 4a8157804d..c222e2cbdf 100644
  static gboolean
  gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
  {
-@@ -1924,6 +2019,10 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
+@@ -1928,6 +2023,10 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
          GST_VIDEO_INFO_WIDTH (&output_state->info);
      GST_VIDEO_INFO_HEIGHT (&thiz->non_msdk_pool_info) =
          GST_VIDEO_INFO_HEIGHT (&output_state->info);

--- a/patches/0025-msdkdec-Apply-the-modified-memory-allocation-logic.patch
+++ b/patches/0025-msdkdec-Apply-the-modified-memory-allocation-logic.patch
@@ -1,4 +1,4 @@
-From b095e1deeb00c759789a82ba737998de734caa39 Mon Sep 17 00:00:00 2001
+From 4c4e5110ab24968548be2d7e330ff3463d66a867 Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Tue, 23 Aug 2022 11:47:02 +0800
 Subject: [PATCH 25/26] msdkdec: Apply the modified memory allocation logic
@@ -15,11 +15,12 @@ when we need to do the gpu to cpu copy.
 (4) In gst_msdkdec_finish_task, we modify the way for copy following the
 logic in (3).
 ---
- .../gst-plugins-bad/sys/msdk/gstmsdkdec.c     | 392 ++++++------------
- 1 file changed, 120 insertions(+), 272 deletions(-)
+ .../gst-plugins-bad/sys/msdk/gstmsdkdec.c     | 426 ++++++------------
+ .../gst-plugins-bad/sys/msdk/gstmsdkdec.h     |   2 +-
+ 2 files changed, 144 insertions(+), 284 deletions(-)
 
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
-index c222e2cbdf..bc8274f028 100644
+index b82d21e31b..55d34b2cdc 100644
 --- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
 +++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
 @@ -40,6 +40,7 @@
@@ -30,7 +31,7 @@ index c222e2cbdf..bc8274f028 100644
  
  #ifndef _WIN32
  #include <gstmsdkallocator_libva.h>
-@@ -70,17 +71,9 @@ static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
+@@ -73,17 +74,9 @@ static GstStaticPadTemplate src_factory = GST_STATIC_PAD_TEMPLATE ("src",
  #define gst_msdkdec_parent_class parent_class
  G_DEFINE_TYPE (GstMsdkDec, gst_msdkdec, GST_TYPE_VIDEO_DECODER);
  
@@ -49,7 +50,7 @@ index c222e2cbdf..bc8274f028 100644
    mfxSyncPoint sync_point;
  
    gboolean decode_only;
-@@ -153,39 +146,22 @@ gst_msdkdec_get_oldest_frame (GstVideoDecoder * decoder)
+@@ -156,39 +149,22 @@ gst_msdkdec_get_oldest_frame (GstVideoDecoder * decoder)
  }
  
  static inline void
@@ -92,7 +93,7 @@ index c222e2cbdf..bc8274f028 100644
        free_surface (surface);
        thiz->locked_msdk_surfaces =
            g_list_delete_link (thiz->locked_msdk_surfaces, l);
-@@ -194,101 +170,6 @@ gst_msdkdec_free_unlocked_msdk_surfaces (GstMsdkDec * thiz)
+@@ -197,101 +173,6 @@ gst_msdkdec_free_unlocked_msdk_surfaces (GstMsdkDec * thiz)
    }
  }
  
@@ -194,7 +195,7 @@ index c222e2cbdf..bc8274f028 100644
  static GstMsdkSurface *
  allocate_output_surface (GstMsdkDec * thiz)
  {
-@@ -696,7 +577,7 @@ static gboolean
+@@ -698,7 +579,7 @@ static gboolean
  gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
  {
    GstVideoCodecState *output_state;
@@ -203,7 +204,7 @@ index c222e2cbdf..bc8274f028 100644
    GstVideoAlignment align;
    GstCaps *allocation_caps = NULL;
    GstCaps *allowed_caps = NULL, *temp_caps;
-@@ -819,13 +700,13 @@ gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
+@@ -821,13 +702,13 @@ gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
  
    /* Ensure output_state->caps and info have same width and height
     * Also, mandate 32 bit alignment */
@@ -222,7 +223,7 @@ index c222e2cbdf..bc8274f028 100644
  #ifndef _WIN32
    if (pad_accept_memory (thiz, GST_CAPS_FEATURE_MEMORY_VA, output_state->caps)) {
      gst_caps_set_features (output_state->caps, 0,
-@@ -905,7 +786,7 @@ gst_msdkdec_set_latency (GstMsdkDec * thiz)
+@@ -907,7 +788,7 @@ gst_msdkdec_set_latency (GstMsdkDec * thiz)
  static gint
  _find_msdk_surface (gconstpointer msdk_surface, gconstpointer comp_surface)
  {
@@ -231,7 +232,7 @@ index c222e2cbdf..bc8274f028 100644
    mfxFrameSurface1 *_surface = (mfxFrameSurface1 *) comp_surface;
  
    return cached_surface ? cached_surface->surface != _surface : -1;
-@@ -914,11 +795,8 @@ _find_msdk_surface (gconstpointer msdk_surface, gconstpointer comp_surface)
+@@ -916,11 +797,8 @@ _find_msdk_surface (gconstpointer msdk_surface, gconstpointer comp_surface)
  static void
  finish_task (GstMsdkDec * thiz, MsdkDecTask * task)
  {
@@ -244,7 +245,73 @@ index c222e2cbdf..bc8274f028 100644
      thiz->locked_msdk_surfaces =
          g_list_append (thiz->locked_msdk_surfaces, surface);
    }
-@@ -964,7 +842,7 @@ gst_msdkdec_finish_task (GstMsdkDec * thiz, MsdkDecTask * task)
+@@ -960,13 +838,73 @@ gst_msdkdec_frame_corruption_report (GstMsdkDec * thiz, mfxU16 corruption)
+         ("[Corruption] Corrupted reference list!"), (NULL));
+ }
+ 
++static gboolean
++_copy_to_sys_mem (GstMsdkDec * thiz, GstMsdkSurface * surface,
++    GstVideoCodecFrame * frame)
++{
++  GstBuffer *buffer = NULL;
++  GstVideoFrame src_frame;
++  GstVideoFrame dst_frame;
++  GstVideoInfo *src_info;
++  GstVideoInfo dst_info;
++  GstVideoCodecState *output_state =
++      gst_video_decoder_get_output_state (GST_VIDEO_DECODER (thiz));
++
++  src_info = &output_state->info;
++  gst_video_info_set_format (&dst_info, GST_VIDEO_INFO_FORMAT (src_info),
++      GST_VIDEO_INFO_WIDTH (src_info), GST_VIDEO_INFO_HEIGHT (src_info));
++
++  if (!gst_buffer_pool_is_active (thiz->other_pool) &&
++      !gst_buffer_pool_set_active (thiz->other_pool, TRUE)) {
++    GST_ERROR_OBJECT (thiz, "Failed to activate buffer pool");
++    return FALSE;
++  }
++
++  if (gst_buffer_pool_acquire_buffer (thiz->other_pool, &buffer, NULL)
++      != GST_FLOW_OK) {
++    GST_ERROR ("Failed to acquire buffer from pool");
++    gst_video_codec_state_unref (output_state);
++    return FALSE;
++  }
++
++  if (!gst_video_frame_map (&src_frame, src_info, surface->buf, GST_MAP_READ)) {
++    GST_ERROR_OBJECT (thiz, "Failed to map buf to src frame");
++    gst_buffer_unref (buffer);
++    gst_video_codec_state_unref (output_state);
++    return FALSE;
++  }
++
++  if (!gst_video_frame_map (&dst_frame, &dst_info, buffer, GST_MAP_WRITE)) {
++    GST_ERROR_OBJECT (thiz, "Failed to map buf to dst frame");
++    gst_buffer_unref (buffer);
++    gst_video_codec_state_unref (output_state);
++    gst_video_frame_unmap (&src_frame);
++    return FALSE;
++  }
++
++  if (!gst_video_frame_copy (&dst_frame, &src_frame)) {
++    GST_ERROR_OBJECT (thiz, "Failed to copy surface data");
++    gst_video_frame_unmap (&src_frame);
++    gst_video_frame_unmap (&dst_frame);
++    return FALSE;
++  }
++
++  frame->output_buffer = gst_buffer_ref (buffer);
++  gst_video_frame_unmap (&src_frame);
++  gst_video_frame_unmap (&dst_frame);
++  gst_buffer_unref (buffer);
++  gst_video_codec_state_unref (output_state);
++
++  return TRUE;
++}
++
+ static GstFlowReturn
+ gst_msdkdec_finish_task (GstMsdkDec * thiz, MsdkDecTask * task)
+ {
    GstVideoDecoder *decoder = GST_VIDEO_DECODER (thiz);
    GstFlowReturn flow;
    GstVideoCodecFrame *frame;
@@ -253,7 +320,7 @@ index c222e2cbdf..bc8274f028 100644
    mfxStatus status;
    guint64 pts = MFX_TIMESTAMP_UNKNOWN;
  
-@@ -1003,15 +881,65 @@ gst_msdkdec_finish_task (GstMsdkDec * thiz, MsdkDecTask * task)
+@@ -1005,16 +943,17 @@ gst_msdkdec_finish_task (GstMsdkDec * thiz, MsdkDecTask * task)
      }
  
      if (G_LIKELY (frame)) {
@@ -269,62 +336,14 @@ index c222e2cbdf..bc8274f028 100644
 -        frame->output_buffer = gst_buffer_ref (surface->copy.buffer);
 -        unmap_frame (thiz, surface);
 +        /* We need to do the copy from video memory to system memory */
-+        GstBuffer *buffer = NULL;
-+        GstVideoFrame src_frame;
-+        GstVideoFrame dst_frame;
-+        GstVideoInfo *src_info;
-+        GstVideoInfo dst_info;
-+        GstVideoCodecState *output_state =
-+            gst_video_decoder_get_output_state (GST_VIDEO_DECODER (thiz));
-+
-+        src_info = &output_state->info;
-+        gst_video_info_set_format (&dst_info, GST_VIDEO_INFO_FORMAT (src_info),
-+            GST_VIDEO_INFO_WIDTH (src_info), GST_VIDEO_INFO_HEIGHT (src_info));
-+
-+        if (!gst_buffer_pool_is_active (thiz->other_pool) &&
-+            !gst_buffer_pool_set_active (thiz->other_pool, TRUE)) {
-+          GST_ERROR_OBJECT (thiz, "Failed to activate buffer pool");
++        if (!_copy_to_sys_mem (thiz, surface, frame))
 +          return GST_FLOW_ERROR;
-+        }
-+
-+        if (gst_buffer_pool_acquire_buffer (thiz->other_pool, &buffer, NULL)
-+            != GST_FLOW_OK) {
-+          GST_ERROR ("Failed to acquire buffer from pool");
-+          gst_video_codec_state_unref (output_state);
-+          return GST_FLOW_ERROR;
-+        }
-+
-+        if (!gst_video_frame_map (&src_frame, src_info, surface->buf,
-+                GST_MAP_READ)) {
-+          GST_ERROR_OBJECT (thiz, "Failed to map buf to src frame");
-+          gst_buffer_unref (buffer);
-+          gst_video_codec_state_unref (output_state);
-+          return GST_FLOW_ERROR;
-+        }
-+
-+        if (!gst_video_frame_map (&dst_frame, &dst_info, buffer, GST_MAP_WRITE)) {
-+          GST_ERROR_OBJECT (thiz, "Failed to map buf to dst frame");
-+          gst_buffer_unref (buffer);
-+          gst_video_codec_state_unref (output_state);
-+          gst_video_frame_unmap (&src_frame);
-+          return GST_FLOW_ERROR;
-+        }
-+
-+        if (!gst_video_frame_copy (&dst_frame, &src_frame)) {
-+          GST_ERROR_OBJECT (thiz, "Failed to copy surface data");
-+          gst_video_frame_unmap (&src_frame);
-+          gst_video_frame_unmap (&dst_frame);
-+          return GST_FLOW_ERROR;
-+        }
-+        frame->output_buffer = gst_buffer_ref (buffer);
-+        gst_video_frame_unmap (&src_frame);
-+        gst_video_frame_unmap (&dst_frame);
-+        gst_buffer_unref (buffer);
-+        gst_video_codec_state_unref (output_state);
        }
++
        GST_DEBUG_OBJECT (thiz, "surface %p TimeStamp: %" G_GUINT64_FORMAT
            " frame %p TimeStamp: %" G_GUINT64_FORMAT,
-@@ -1032,6 +960,7 @@ gst_msdkdec_finish_task (GstMsdkDec * thiz, MsdkDecTask * task)
+           surface->surface, (guint64) surface->surface->Data.TimeStamp,
+@@ -1036,6 +975,7 @@ gst_msdkdec_finish_task (GstMsdkDec * thiz, MsdkDecTask * task)
      return flow;
    }
    finish_task (thiz, task);
@@ -332,7 +351,7 @@ index c222e2cbdf..bc8274f028 100644
    return GST_FLOW_OK;
  }
  
-@@ -1174,13 +1103,12 @@ static void
+@@ -1178,13 +1118,12 @@ static void
  release_msdk_surfaces (GstMsdkDec * thiz)
  {
    GList *l;
@@ -348,7 +367,7 @@ index c222e2cbdf..bc8274f028 100644
      free_surface (surface);
      locked++;
    }
-@@ -1280,7 +1208,7 @@ find_msdk_surface (GstMsdkDec * thiz, MsdkDecTask * task,
+@@ -1284,7 +1223,7 @@ find_msdk_surface (GstMsdkDec * thiz, MsdkDecTask * task,
      GST_ERROR_OBJECT (thiz, "msdk return an invalid surface %p", out_surface);
      return FALSE;
    }
@@ -357,7 +376,7 @@ index c222e2cbdf..bc8274f028 100644
    thiz->locked_msdk_surfaces =
        g_list_delete_link (thiz->locked_msdk_surfaces, l);
    return TRUE;
-@@ -1353,11 +1281,11 @@ gst_msdkdec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
+@@ -1357,11 +1296,11 @@ gst_msdkdec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
    GstMsdkDec *thiz = GST_MSDKDEC (decoder);
    GstMsdkDecClass *klass = GST_MSDKDEC_GET_CLASS (thiz);
    GstFlowReturn flow;
@@ -371,7 +390,7 @@ index c222e2cbdf..bc8274f028 100644
    mfxFrameSurface1 *out_surface = NULL;
    mfxSession session;
    mfxStatus status;
-@@ -1527,13 +1455,7 @@ gst_msdkdec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
+@@ -1531,13 +1470,7 @@ gst_msdkdec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
        goto error;
      }
      if (!surface) {
@@ -386,7 +405,7 @@ index c222e2cbdf..bc8274f028 100644
        if (!surface) {
          /* Can't get a surface for some reason; finish tasks, then see if
             a surface becomes available. */
-@@ -1543,7 +1465,7 @@ gst_msdkdec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
+@@ -1547,7 +1480,7 @@ gst_msdkdec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
            flow = gst_msdkdec_finish_task (thiz, task);
            if (flow != GST_FLOW_OK)
              goto error;
@@ -395,7 +414,7 @@ index c222e2cbdf..bc8274f028 100644
            if (surface)
              break;
          }
-@@ -1708,91 +1630,6 @@ gst_msdkdec_parse (GstVideoDecoder * decoder, GstVideoCodecFrame * frame,
+@@ -1712,91 +1645,6 @@ gst_msdkdec_parse (GstVideoDecoder * decoder, GstVideoCodecFrame * frame,
    return ret;
  }
  
@@ -487,7 +506,7 @@ index c222e2cbdf..bc8274f028 100644
  #ifndef _WIN32
  static GstBufferPool *
  gst_msdk_create_va_pool (GstMsdkDec * thiz, GstVideoInfo * info,
-@@ -1837,7 +1674,7 @@ gst_msdk_create_va_pool (GstMsdkDec * thiz, GstVideoInfo * info,
+@@ -1841,7 +1689,7 @@ gst_msdk_create_va_pool (GstMsdkDec * thiz, GstVideoInfo * info,
  #endif
  
  static GstBufferPool *
@@ -496,7 +515,7 @@ index c222e2cbdf..bc8274f028 100644
      guint num_buffers)
  {
    GstBufferPool *pool = NULL;
-@@ -1900,7 +1737,7 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
+@@ -1904,7 +1752,7 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
    GstStructure *pool_config = NULL;
    GstCaps *pool_caps /*, *negotiated_caps */ ;
    guint size, min_buffers, max_buffers;
@@ -505,7 +524,7 @@ index c222e2cbdf..bc8274f028 100644
  
    if (!thiz->param.mfx.FrameInfo.Width || !thiz->param.mfx.FrameInfo.Height)
      return FALSE;
-@@ -1915,6 +1752,11 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
+@@ -1919,6 +1767,11 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
    gst_query_parse_nth_allocation_pool (query, 0, &pool, NULL, NULL, NULL);
    pool_config = gst_buffer_pool_get_config (pool);
  
@@ -517,7 +536,7 @@ index c222e2cbdf..bc8274f028 100644
    /* Get the caps of pool and increase the min and max buffers by async_depth.
     * We will always have that number of decode operations in-flight */
    gst_buffer_pool_config_get_params (pool_config, &pool_caps, &size,
-@@ -1930,21 +1772,8 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
+@@ -1934,21 +1787,8 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
    thiz->min_prealloc_buffers = min_buffers;
  
    if (_gst_caps_has_feature (pool_caps, GST_CAPS_FEATURE_MEMORY_DMABUF)) {
@@ -541,7 +560,7 @@ index c222e2cbdf..bc8274f028 100644
    /* Decoder always use its own pool. So we create a pool if msdk APIs
     * previously requested for allocation (do_realloc = TRUE) */
    if (thiz->do_realloc || !thiz->pool) {
-@@ -1960,23 +1789,21 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
+@@ -1964,24 +1804,22 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
        goto failed_to_create_pool;
      }
    }
@@ -554,27 +573,48 @@ index c222e2cbdf..bc8274f028 100644
 -    if (!(GST_IS_MSDK_VIDEO_ALLOCATOR (allocator) ||
 -            GST_IS_MSDK_DMABUF_ALLOCATOR (allocator) ||
 -            GST_IS_MSDK_SYSTEM_ALLOCATOR (allocator)))
+-      thiz->ds_has_no_msdk_allocator = TRUE;
 +    if (!(GST_IS_VA_ALLOCATOR (allocator) ||
 +            GST_IS_VA_DMABUF_ALLOCATOR (allocator)))
-       thiz->ds_has_no_msdk_allocator = TRUE;
++      thiz->ds_has_known_allocator = FALSE;
    }
 +#endif
  
-   /* If downstream supports video meta and video alignment,
-    * or downstream doesn't have msdk_allocator, we can replace
-    * with our own msdk bufferpool and use it.
+-  /* If downstream supports video meta and video alignment,
+-   * or downstream doesn't have msdk_allocator, we can replace
+-   * with our own msdk bufferpool and use it.
++  /* If downstream supports video meta and video alignment, or downstream
++   * doesn't have known allocator (known allocator refers to va allocator
++   * or d3d allocator), we replace with our own bufferpool and use it.
     */
 -  if ((gst_query_find_allocation_meta (query, GST_VIDEO_META_API_TYPE, NULL)
 -          && gst_buffer_pool_has_option
 -          (pool, GST_BUFFER_POOL_OPTION_VIDEO_ALIGNMENT))
+-      || thiz->ds_has_no_msdk_allocator) {
 +  if ((has_videometa && has_video_alignment)
-       || thiz->ds_has_no_msdk_allocator) {
++      || !thiz->ds_has_known_allocator) {
      GstStructure *config;
      GstAllocator *allocator;
-@@ -2020,9 +1847,32 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
+ 
+@@ -1998,9 +1836,9 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
+       gst_query_set_nth_allocation_param (query, 0, allocator, NULL);
+     gst_structure_free (config);
+   } else {
+-    /* Unfortunately, downstream doesn't have videometa or alignment support,
+-     * we keep msdk pool as a side-pool that will be decoded into and
+-     * then copied from.
++    /* When downstream doesn't have videometa or alignment support,
++     * or downstream pool is va/d3d pool,we will use downstream pool
++     * and keep decoder's own pool as side-pool.
+      */
+     GstVideoCodecState *output_state = NULL;
+ 
+@@ -2024,9 +1862,33 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
      GST_VIDEO_INFO_HEIGHT (&thiz->non_msdk_pool_info) =
          GST_VIDEO_INFO_HEIGHT (&output_state->info);
  
+-    /* When downstream allocator is unknown and negotiaed caps is raw,
+-     * we need to create other pool with system memory for copy use
 +    gst_video_codec_state_unref (output_state);
 +  }
 +
@@ -590,11 +630,12 @@ index c222e2cbdf..bc8274f028 100644
 +  /* get the updated min_buffers, which account for the msdk requirement as well */
 +  min_buffers = thiz->min_prealloc_buffers;
 +
-+  if (!has_videometa && thiz->ds_has_no_msdk_allocator
++  if (!has_videometa && !thiz->ds_has_known_allocator
 +      && _gst_caps_has_feature (pool_caps,
 +          GST_CAPS_FEATURE_MEMORY_SYSTEM_MEMORY)) {
-     /* When downstream allocator is unknown and negotiaed caps is raw,
-      * we need to create other pool with system memory for copy use
++    /* We need to create other pool with system memory for copy use under conditions:
++     * (1) downstream has no videometa; (2) downstream allocator is unknown;
++     * (3) negotiated caps is raw.
       */
 +    thiz->do_copy = TRUE;
 +    GstVideoCodecState *output_state =
@@ -604,7 +645,7 @@ index c222e2cbdf..bc8274f028 100644
      gst_video_codec_state_unref (output_state);
    }
  
-@@ -2032,7 +1882,6 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
+@@ -2036,7 +1898,6 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
    if (pool)
      gst_object_unref (pool);
  
@@ -612,7 +653,7 @@ index c222e2cbdf..bc8274f028 100644
    return TRUE;
  
  failed_to_create_pool:
-@@ -2053,9 +1902,8 @@ gst_msdkdec_drain (GstVideoDecoder * decoder)
+@@ -2057,9 +1918,8 @@ gst_msdkdec_drain (GstVideoDecoder * decoder)
  {
    GstMsdkDec *thiz = GST_MSDKDEC (decoder);
    GstFlowReturn flow;
@@ -623,7 +664,7 @@ index c222e2cbdf..bc8274f028 100644
    mfxFrameSurface1 *out_surface;
    mfxSession session;
    mfxStatus status;
-@@ -2075,10 +1923,7 @@ gst_msdkdec_drain (GstVideoDecoder * decoder)
+@@ -2079,10 +1939,7 @@ gst_msdkdec_drain (GstVideoDecoder * decoder)
      }
  
      if (!surface) {
@@ -635,7 +676,13 @@ index c222e2cbdf..bc8274f028 100644
        if (!surface)
          return GST_FLOW_ERROR;
      }
-@@ -2386,4 +2231,7 @@ gst_msdkdec_init (GstMsdkDec * thiz)
+@@ -2385,9 +2242,12 @@ gst_msdkdec_init (GstMsdkDec * thiz)
+   thiz->force_reset_on_res_change = TRUE;
+   thiz->report_error = FALSE;
+   thiz->sfc = FALSE;
+-  thiz->ds_has_no_msdk_allocator = FALSE;
++  thiz->ds_has_known_allocator = TRUE;
+   thiz->adapter = gst_adapter_new ();
    thiz->input_state = NULL;
    thiz->pool = NULL;
    thiz->context = NULL;
@@ -643,6 +690,19 @@ index c222e2cbdf..bc8274f028 100644
 +  thiz->use_video_memory = TRUE;
 +#endif
  }
+diff --git a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.h b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.h
+index fa9ea0e176..2ff2f8d795 100644
+--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.h
++++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.h
+@@ -79,7 +79,7 @@ struct _GstMsdkDec
+   gboolean do_copy;
+   gboolean initialized;
+   gboolean sfc;
+-  gboolean ds_has_no_msdk_allocator;
++  gboolean ds_has_known_allocator;
+ 
+   /* for packetization */
+   GstAdapter *adapter;
 -- 
 2.25.1
 

--- a/patches/0026-msdkdec-Check-available-surfaces-when-all-pre-alloca.patch
+++ b/patches/0026-msdkdec-Check-available-surfaces-when-all-pre-alloca.patch
@@ -1,4 +1,4 @@
-From cdc668f7c943ea33bcfb993985b81d747a936397 Mon Sep 17 00:00:00 2001
+From ff4658723bf356e2ae4c3526a34f5b7d38a5b86a Mon Sep 17 00:00:00 2001
 From: Mengkejiergeli Ba <mengkejiergeli.ba@intel.com>
 Date: Tue, 23 Aug 2022 14:20:35 +0800
 Subject: [PATCH 26/26] msdkdec: Check available surfaces when all
@@ -9,10 +9,10 @@ Subject: [PATCH 26/26] msdkdec: Check available surfaces when all
  1 file changed, 38 insertions(+), 5 deletions(-)
 
 diff --git a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
-index bc8274f028..e823a0b629 100644
+index 55d34b2cdc..8cfbe84bff 100644
 --- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
 +++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
-@@ -152,8 +152,9 @@ free_surface (GstMsdkSurface * s)
+@@ -155,8 +155,9 @@ free_surface (GstMsdkSurface * s)
    g_slice_free (GstMsdkSurface, s);
  }
  
@@ -24,7 +24,7 @@ index bc8274f028..e823a0b629 100644
  {
    GList *l;
    GstMsdkSurface *surface;
-@@ -161,13 +162,27 @@ gst_msdkdec_free_unlocked_msdk_surfaces (GstMsdkDec * thiz)
+@@ -164,13 +165,27 @@ gst_msdkdec_free_unlocked_msdk_surfaces (GstMsdkDec * thiz)
    for (l = thiz->locked_msdk_surfaces; l;) {
      GList *next = l->next;
      surface = l->data;
@@ -53,7 +53,7 @@ index bc8274f028..e823a0b629 100644
  }
  
  static GstMsdkSurface *
-@@ -179,10 +194,28 @@ allocate_output_surface (GstMsdkDec * thiz)
+@@ -182,10 +197,28 @@ allocate_output_surface (GstMsdkDec * thiz)
    GstMemory *mem = NULL;
    mfxFrameSurface1 *mfx_surface = NULL;
  #endif
@@ -83,7 +83,7 @@ index bc8274f028..e823a0b629 100644
  #ifndef _WIN32
    if ((gst_buffer_pool_acquire_buffer (thiz->alloc_pool, &out_buffer, NULL))
        != GST_FLOW_OK) {
-@@ -1105,7 +1138,7 @@ release_msdk_surfaces (GstMsdkDec * thiz)
+@@ -1120,7 +1153,7 @@ release_msdk_surfaces (GstMsdkDec * thiz)
    GList *l;
    GstMsdkSurface *surface;
    gint locked = 0;


### PR DESCRIPTION
1. Change decoder's va pool usage_hint flag to VA_SURFACE_ATTRIB_USAGE_HINT_DECODER.
2. Rename ds_has_no_msdk_allocator to ds_has_known_allocator, because we no longer use additional wrapping of msdk allocator. Instead, decoder can directly recognize va or d3d allocator.
3. Integrate "do_copy" multiple lines of codes in gst_mskdec_finish_task to a helper function (named as _copy_to_sys_mem).